### PR TITLE
Do insert during tests

### DIFF
--- a/tests/phpunit/RemoteWikiTest.php
+++ b/tests/phpunit/RemoteWikiTest.php
@@ -58,7 +58,7 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
 			);
 
 		} catch ( DBQueryError $e ) {
-			return;
+			// Do nothing
 		}
 
 		$db = MediaWikiServices::getInstance()->getDatabaseFactory()->create( 'mysql', [


### PR DESCRIPTION
To fix PHPUnit running, it is needed both here and in https://github.com/WikiForge/ci-scripts/blob/master/mediawiki/globals/setup-CreateWiki.php in order to work with MediaWiki 1.40 as well.
- setup-CreateWiki having it in MediaWikiServices hook, using DatabaseFactory works for initial install.php step of CI, as we can no longer have an active DBLoadBalancer service in MediaWikiServices in 1.40 due to `MediaWikiServices::disableStorage()` being called in some maintenance scripts.
- These tests don't read what the installer added, as it needs to be installed with the normal MediaWikiServices method, so since we are still functional up to this point now, we can run them again here, and it works to install wikidb, and let the tests understand that properly.