### PR TITLE
WikiManager: use run.php wrapper for MediaWiki 1.40

### DIFF
--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -166,20 +166,27 @@ class WikiManager {
 
 		DeferredUpdates::addCallableUpdate(
 			function () use ( $wiki, $requester, $centralAuth ) {
+				$scriptOptions = [];
+				if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
+					$scriptOptions = [ 'wrapper' => MW_INSTALL_PATH . '/maintenance/run.php' ];
+				}
+
 				$this->recacheJson();
 
 				Shell::makeScriptCommand(
 					MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/setContainersAccess.php',
 					[
 						'--wiki', $wiki
-					]
+					],
+					$scriptOptions
 				)->limits( [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ] )->execute();
 
 				Shell::makeScriptCommand(
 					MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/populateMainPage.php',
 					[
 						'--wiki', $wiki
-					]
+					],
+					$scriptOptions
 				)->limits( [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ] )->execute();
 
 				if ( $centralAuth ) {
@@ -189,7 +196,8 @@ class WikiManager {
 							[
 								$requester,
 								'--wiki', $wiki
-							]
+							],
+							$scriptOptions
 						)->limits( [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ] )->execute();
 					}
 
@@ -202,7 +210,8 @@ class WikiManager {
 							'--sysop',
 							'--force',
 							'--wiki', $wiki
-						]
+						],
+						$scriptOptions
 					)->limits( [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ] )->execute();
 				}
 			},


### PR DESCRIPTION
This is the default on MediaWiki 1.41+ but is good for MediaWiki 1.40 also.