### PR TITLE
ManageInactiveWikis: use run.php wrapper for MediaWiki 1.40

### DIFF
--- a/maintenance/manageInactiveWikis.php
+++ b/maintenance/manageInactiveWikis.php
@@ -65,11 +65,17 @@ class ManageInactiveWikis extends Maintenance {
 
 		$canWrite = $this->hasOption( 'write' );
 
+		$scriptOptions = [];
+		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
+			$scriptOptions = [ 'wrapper' => MW_INSTALL_PATH . '/maintenance/run.php' ];
+		}
+
 		$timeStamp = Shell::makeScriptCommand(
 			MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/checkLastWikiActivity.php',
 			[
 				'--wiki', $dbName
-			]
+			],
+			$scriptOptions
 		)
 			->limits( [ 'filesize' => 0, 'memory' => 0, 'time' => 0, 'walltime' => 0 ] )
 			->execute();


### PR DESCRIPTION
This is the default on MediaWiki 1.41+ but is good for MediaWiki 1.40 also.